### PR TITLE
Replace match with if to be compatible with Python < 3.10

### DIFF
--- a/icdmappings/icdmappings.py
+++ b/icdmappings/icdmappings.py
@@ -99,9 +99,7 @@ class Validator():
 
         validator, _type = self._internal_validators.get(expects)
 
-        match _type:
-
-            case 'diagnostic':
-                return validator.validate_diagnostics(codes)
-            case 'procedure':
-                return validator.validate_procedures(codes)
+        if _type == 'diagnostic':
+            return validator.validate_diagnostics(codes)
+        elif _type == 'procedure':
+            return validator.validate_procedures(codes)


### PR DESCRIPTION
I wanted to use icd-mappings in one of my projects, but realized that it requires Python 3.10, although its pyproject.toml states that icd-mappings should work with Python 3.8 or higher.

The issue is the match clause in icdmappings.py, which was first introduced in Python 3.10. By replacing it with an if, we ensure that icd-mappings can also be used in projects that cannot use Python 3.10 yet.