### PR TITLE
strip dots from input codes in all mappers

### DIFF
--- a/icdmappings/mappers/icd10_to_blocks.py
+++ b/icdmappings/mappers/icd10_to_blocks.py
@@ -35,7 +35,8 @@ class ICD10toBlocks(MapperInterface):
 
             if not isinstance(icd10code, str): # has to be string
                 return None
-            
+
+            icd10code = icd10code.replace('.', '')
 
             letter = icd10code[0]
 

--- a/icdmappings/mappers/icd10_to_ccir.py
+++ b/icdmappings/mappers/icd10_to_ccir.py
@@ -16,7 +16,9 @@ class ICD10toCCIR:
             self.icd10_to_ccir = self._parse_file(self.filename) # {icd10code:cci,...icd10code:cci}
 
         def _map_single(self, icd10code : str) -> str:
-             return self.icd10_to_ccir.get(icd10code)
+            if isinstance(icd10code, str):
+                icd10code = icd10code.replace('.', '')
+            return self.icd10_to_ccir.get(icd10code)
 
 
         def map(self, icd10code : Union[str, Iterable]) -> Union[str, Iterable]:

--- a/icdmappings/mappers/icd10_to_ccsr.py
+++ b/icdmappings/mappers/icd10_to_ccsr.py
@@ -43,7 +43,8 @@ class ICD10toCCSR(MapperInterface):
 
             if not isinstance(icd10code, str): # has to be string
                 return None
-            
+
+            icd10code = icd10code.replace('.', '')
             return self.ccsr_lookup.get(icd10code)
 
 

--- a/icdmappings/mappers/icd10_to_chapters.py
+++ b/icdmappings/mappers/icd10_to_chapters.py
@@ -36,7 +36,8 @@ class ICD10toChapters(MapperInterface):
 
             if not isinstance(icd10code, str): # has to be string
                 return None
-            
+
+            icd10code = icd10code.replace('.', '')
 
             letter = icd10code[0]
             if letter not in self.chapter_lookup:

--- a/icdmappings/mappers/icd10_to_icd9.py
+++ b/icdmappings/mappers/icd10_to_icd9.py
@@ -21,6 +21,8 @@ class ICD10toICD9(MapperInterface):
 
 
     def _map_single(self, icd10code : str):
+        if isinstance(icd10code, str):
+            icd10code = icd10code.replace('.', '')
         return self.icd10_to_icd9.get(icd10code)
 
     def map(self, icd10code : Union[str, Iterable]) -> Union[str, Iterable]:

--- a/icdmappings/mappers/icd9_to_cci.py
+++ b/icdmappings/mappers/icd9_to_cci.py
@@ -22,7 +22,9 @@ class ICD9toCCI:
             self.icd9_to_cci = self._parse_file(self.filename)
 
         def _map_single(self, icd9code : str) -> str:
-             return self.icd9_to_cci.get(icd9code)
+            if isinstance(icd9code, str):
+                icd9code = icd9code.replace('.', '')
+            return self.icd9_to_cci.get(icd9code)
 
 
         def map(self, icd9code : Union[str, Iterable]) -> Union[str, Iterable]:

--- a/icdmappings/mappers/icd9_to_ccs.py
+++ b/icdmappings/mappers/icd9_to_ccs.py
@@ -30,6 +30,8 @@ class ICD9toCCS(MapperInterface):
             return self._get_codes(content)
         
         def _map_single(self, icd9code : str) -> str:
+            if isinstance(icd9code, str):
+                icd9code = icd9code.replace('.', '')
             return self.icd9_to_ccs.get(icd9code)
 
         def map(self,icd9code: Union[str, Iterable]) -> Union[str, Iterable]:

--- a/icdmappings/mappers/icd9_to_chapters.py
+++ b/icdmappings/mappers/icd9_to_chapters.py
@@ -40,7 +40,9 @@ class ICD9toChapters(MapperInterface):
 
             if not isinstance(icd9code, str): # has to be string
                 return None
-            
+
+            icd9code = icd9code.replace('.', '')
+
             if icd9code[0] in ['E','V']:
                 return self.char_mapping[icd9code[0]]
             else: # numerical code

--- a/icdmappings/mappers/icd9_to_icd10.py
+++ b/icdmappings/mappers/icd9_to_icd10.py
@@ -21,7 +21,8 @@ class ICD9toICD10(MapperInterface):
         self.icd9_to_icd10 = self._parse_file(self.filename)
 
     def _map_single(self, icd9code : str):
-            
+        if isinstance(icd9code, str):
+            icd9code = icd9code.replace('.', '')
         return self.icd9_to_icd10.get(icd9code)
 
     def map(self, icd9code : Union[str, Iterable]) -> Union[str, Iterable]:

--- a/tests/test_icd10_to_blocks.py
+++ b/tests/test_icd10_to_blocks.py
@@ -15,18 +15,21 @@ def test_mapper():
     mapper = ICD10toBlocks()
 
     expected_mappings = {
-        'H05243'     : 'H00-H06', 
-        'A0105'      : 'A00-A09', 
-        'B658'       : 'B65-B83', 
-        'C8333'      : 'C81-C96', 
+        'H05243'     : 'H00-H06',
+        'A0105'      : 'A00-A09',
+        'B658'       : 'B65-B83',
+        'C8333'      : 'C81-C96',
         'D421'       : 'D37-D48',
         'D4981'      : None,       # valid code but there's no mapping for it
-        'D528'       : 'D50-D53', 
+        'D528'       : 'D50-D53',
         'M84651K'    : 'M80-M94',
-        'L03114'     : 'L00-L08', 
+        'L03114'     : 'L00-L08',
         'Not a code' : None,
         62719        : None,
         'T25519D'    : 'T20-T32',
+        # Test codes with dots - should work after dot stripping
+        'H05.243'    : 'H00-H06',  # same as 'H05243'
+        'A01.05'     : 'A00-A09',  # same as 'A0105'
     } 
     
     for code, expected in expected_mappings.items():

--- a/tests/test_icd10_to_ccir.py
+++ b/tests/test_icd10_to_ccir.py
@@ -11,18 +11,21 @@ def test_mapper():
     from icdmappings.mappers import ICD10toCCIR
     mapper = ICD10toCCIR()
 
-    expected_mappings = {'H05243':True, 
-                         'A0105': False, 
-                         'B658': False, 
+    expected_mappings = {'H05243':True,
+                         'A0105': False,
+                         'B658': False,
                          'C8333': True,
                          'D421': True,
                          'D4981': False,
-                         'D528': True, 
+                         'D528': True,
                          'M84651K': False,
-                         'L03114': False, 
+                         'L03114': False,
                          'Not a code':None,
                           62719: None,
-                         'T25519D': False
+                         'T25519D': False,
+                         # Test codes with dots - should work after dot stripping
+                         'H05.243': True,   # same as 'H05243'
+                         'A01.05': False,   # same as 'A0105'
                         }
     for code, expected in expected_mappings.items():
         result = mapper.map(code)

--- a/tests/test_icd10_to_ccsr.py
+++ b/tests/test_icd10_to_ccsr.py
@@ -11,18 +11,21 @@ def test_mapper():
     from icdmappings.mappers import ICD10toCCSR
     mapper = ICD10toCCSR()
 
-    expected_mappings = {'H05243':'EYE008', 
-                         'A0105': 'INF003', 
-                         'B658': 'INF009', 
-                         'C8333': 'NEO058', 
+    expected_mappings = {'H05243':'EYE008',
+                         'A0105': 'INF003',
+                         'B658': 'INF009',
+                         'C8333': 'NEO058',
                          'D421': 'NEO072',
                          'D4981': 'NEO072',
-                         'D528': 'BLD001', 
+                         'D528': 'BLD001',
                          'M84651K': 'MUS015',
-                         'L03114': 'SKN001', 
+                         'L03114': 'SKN001',
                          'Not a code':None,
                           62719: None,
-                         'T25519D': 'INJ056'
+                         'T25519D': 'INJ056',
+                         # Test codes with dots - should work after dot stripping
+                         'H05.243': 'EYE008',  # same as 'H05243'
+                         'A01.05': 'INF003',   # same as 'A0105'
                         } 
     
     for code, expected in expected_mappings.items():

--- a/tests/test_icd10_to_chapters.py
+++ b/tests/test_icd10_to_chapters.py
@@ -11,18 +11,21 @@ def test_mapper():
     from icdmappings.mappers import ICD10toChapters
     mapper = ICD10toChapters()
 
-    expected_mappings = {'H05243':'7', 
-                         'A0105': '1', 
-                         'B658': '1', 
-                         'C8333': '2', 
+    expected_mappings = {'H05243':'7',
+                         'A0105': '1',
+                         'B658': '1',
+                         'C8333': '2',
                          'D421': '2',
                          'D4981': None, # valid code but there's no mapping for it
-                         'D528': '3', 
+                         'D528': '3',
                          'M84651K': '13',
-                         'L03114': '12', 
+                         'L03114': '12',
                          'Not a code':None,
                           62719: None,
-                         'T25519D': '19'
+                         'T25519D': '19',
+                         # Test codes with dots - should work after dot stripping
+                         'H05.243': '7',  # same as 'H05243'
+                         'A01.05': '1',   # same as 'A0105'
                         } 
     
     for code, expected in expected_mappings.items():

--- a/tests/test_icd10_to_icd9.py
+++ b/tests/test_icd10_to_icd9.py
@@ -31,7 +31,18 @@ def test_mapper():
     result = mapper.map(code)
     assert result is expected
 
-    code = ["A0224",123, "A179", "", "812938"]
-    expected = ["00324", None, "01790", None, None]
+    # Test codes with dots - should work after dot stripping
+    code = "A02.24"
+    expected = "00324"  # same as "A0224"
+    result = mapper.map(code)
+    assert result == expected
+
+    code = "A1.79"
+    expected = "01790"  # same as "A179"
+    result = mapper.map(code)
+    assert result == expected
+
+    code = ["A0224", 123, "A179", "", "812938", "A02.24"]
+    expected = ["00324", None, "01790", None, None, "00324"]  # "A02.24" now maps correctly
     result = mapper.map(code)
     assert result == expected

--- a/tests/test_icd9_to_cci.py
+++ b/tests/test_icd9_to_cci.py
@@ -36,7 +36,18 @@ def test_mapper():
     result = mapper.map(code)
     assert result is expected
 
-    code = ["20104", 123, "4613"]
-    expected = [True, None, False]
+    # Test codes with dots - should work after dot stripping
+    code = "999.0"
+    expected = False  # same as "9990"
+    result = mapper.map(code)
+    assert result == expected
+
+    code = "V45.0"
+    expected = True  # same as "V450"
+    result = mapper.map(code)
+    assert result == expected
+
+    code = ["20104", 123, "4613", "999.0", "V45.0"]
+    expected = [True, None, False, False, True]  # dotted codes now map correctly
     result = mapper.map(code)
     assert result == expected

--- a/tests/test_icd9_to_ccs.py
+++ b/tests/test_icd9_to_ccs.py
@@ -31,7 +31,18 @@ def test_mapper():
     result = mapper.map(code)
     assert result is expected
 
-    code = ["20104",123, "4339", "", "918283818"]
-    expected = ["37", None, "110", None, None]
+    # Test codes with dots - should work after dot stripping
+    code = "53.52"
+    expected = "140"  # same as "5352"
+    result = mapper.map(code)
+    assert result == expected
+
+    code = "201.04"
+    expected = "37"  # same as "20104"
+    result = mapper.map(code)
+    assert result == expected
+
+    code = ["20104", 123, "4339", "", "918283818", "53.52"]
+    expected = ["37", None, "110", None, None, "140"]  # "53.52" now maps correctly
     result = mapper.map(code)
     assert result == expected

--- a/tests/test_icd9_to_chapters.py
+++ b/tests/test_icd9_to_chapters.py
@@ -42,3 +42,19 @@ def test_mapper():
     will_get = mapper.map("152")
     result = mapper.map(code)
     assert will_get == result
+
+    # Test codes with dots - should work after dot stripping
+    code = "535.2"
+    expected = "9"  # same as "5352"
+    result = mapper.map(code)
+    assert result == expected
+
+    code = "201.04"
+    expected = "2"  # same as "20104"
+    result = mapper.map(code)
+    assert result == expected
+
+    code = ["20104", "535.2", "201.04"]
+    expected = ["2", "9", "2"]  # dotted codes now map correctly
+    result = mapper.map(code)
+    assert result == expected

--- a/tests/test_icd9_to_icd10.py
+++ b/tests/test_icd9_to_icd10.py
@@ -36,7 +36,18 @@ def test_mapper():
     result = mapper.map(code)
     assert result is expected
 
-    code = ["00863",123, "0402", "", "008.63"]
-    expected = ["A0811", None, "K9081", None, None]
+    # Test codes with dots - should work after dot stripping
+    code = "008.63"
+    expected = "A0811"  # same as "00863"
+    result = mapper.map(code)
+    assert result == expected
+
+    code = "04.02"
+    expected = "K9081"  # same as "0402"
+    result = mapper.map(code)
+    assert result == expected
+
+    code = ["00863", 123, "0402", "", "008.63"]
+    expected = ["A0811", None, "K9081", None, "A0811"]  # "008.63" now maps to "A0811"
     result = mapper.map(code)
     assert result == expected


### PR DESCRIPTION
Codes containing dots (e.g., "008.63") are now automatically cleaned to their dot-free equivalent (e.g., "00863") before mapping. This allows users to input codes in either format and get consistent results.